### PR TITLE
Add manager structure

### DIFF
--- a/app/Models/Manager.php
+++ b/app/Models/Manager.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\User;
+use Spatie\ModelStates\HasStates;
+use App\States\Manager\ManagerState;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Manager extends Model
+{
+    use HasFactory, HasStates, HasUlids;
+
+    protected $table = 'managers';
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'document',
+        'birth_date',
+        'status',
+    ];
+
+    protected $casts = [
+        'user_id' => 'ulid',
+        'status' => ManagerState::class,
+        'name' => 'encrypted',
+        'document' => 'encrypted',
+        'birth_date' => 'encrypted',
+    ];
+
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/States/Manager/Created.php
+++ b/app/States/Manager/Created.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\States\Manager;
+
+final class Created extends ManagerState
+{
+    public static string $name = 'created';
+}

--- a/app/States/Manager/ManagerState.php
+++ b/app/States/Manager/ManagerState.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\States\Manager;
+
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+abstract class ManagerState extends State
+{
+    final public static function config(): StateConfig
+    {
+        return parent::config()
+            ->default(Created::class);
+    }
+}

--- a/app/States/Manager/WaitingOnboarding.php
+++ b/app/States/Manager/WaitingOnboarding.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\States\Manager;
+
+final class WaitingOnboarding extends ManagerState
+{
+    public static string $name = 'waiting_onboarding';
+}

--- a/database/factories/ManagerFactory.php
+++ b/database/factories/ManagerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\Manager;
+use App\States\Manager\ManagerState;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Manager>
+ */
+class ManagerFactory extends Factory
+{
+    protected $model = Manager::class;
+
+    public function definition(): array
+    {
+        $status = ManagerState::all()->random();
+
+        return [
+            'user_id' => User::factory(),
+            'name' => $this->faker->name(),
+            'document' => $this->faker->unique()->numerify('###########'),
+            'birth_date' => $this->faker->dateTimeBetween('-30 years', '-18 years'),
+            'status' => $status,
+        ];
+    }
+}

--- a/database/migrations/2025_05_09_104935_create_managers_table.php
+++ b/database/migrations/2025_05_09_104935_create_managers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\States\Manager\Created;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('managers', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('user_id')->constrained();
+            $table->string('name', 200)->nullable();
+            $table->string('document', 20)->unique()->nullable();
+            $table->dateTime('birth_date')->nullable();
+            $table->string('status', 50)->default(Created::$name);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('managers');
+    }
+};


### PR DESCRIPTION
## 📝 Description

This PR aims to add manager initial structure.

## 🎯 Context and Motivation

In order to create maintanence request, it's necessary to have managers in the system

## ✅ How to Test / How It Was Tested
It was tested locally

## 🛠️ Commands and Additional Info

`php artisan migrate
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for managing manager profiles, including storing personal details and onboarding status.
  - Introduced new manager states such as "created" and "waiting onboarding" for enhanced status tracking.
- **Database**
  - Added a new managers table to store manager information.
- **Tests**
  - Provided factory support for generating manager data for testing and seeding purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->